### PR TITLE
Fix MCP publish dependency install

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/requirements.txt
+          pip install -e .
           pip install pytest
 
       - name: Import check -- mcp_server


### PR DESCRIPTION
## Summary
- install kubeopt-mcp itself during the publish workflow CI gate
- ensures MCP 2.0 dependencies are present before import and tool registration checks

## Verification
- .venv/bin/python -c "from mcp_server.server import server, run; print('import OK')"
- tool registration check confirms 6 tools
- UV_CACHE_DIR=/private/tmp/kubeopt-uv-cache uv build