### PR TITLE
Fix collector freshness and dashboard empty metrics

### DIFF
--- a/frontend/src/components/charts/NodeUtilizationChart.tsx
+++ b/frontend/src/components/charts/NodeUtilizationChart.tsx
@@ -18,13 +18,19 @@ export default function NodeUtilizationChart({ data }: NodeUtilizationProps) {
     if (key) setHidden((prev) => ({ ...prev, [key]: !prev[key] }))
   }, [])
 
-  if (!data.length) {
+  const chartData = data.map((d) => ({
+    ...d,
+    cpu: Number.isFinite(d.cpu) ? d.cpu : 0,
+    memory: Number.isFinite(d.memory) ? d.memory : 0,
+  }))
+
+  if (!chartData.length) {
     return <div className="py-8 text-center text-dark-400">No node data available</div>
   }
 
   return (
     <ResponsiveContainer width="100%" height={280}>
-      <BarChart data={data} margin={{ bottom: 20, right: 8 }}>
+      <BarChart data={chartData} margin={{ bottom: 20, right: 8 }}>
         <CartesianGrid stroke="var(--border-subtle)" strokeOpacity={0.5} vertical={false} />
         <XAxis
           dataKey="name"

--- a/frontend/src/components/charts/ResourceUtilizationChart.tsx
+++ b/frontend/src/components/charts/ResourceUtilizationChart.tsx
@@ -12,12 +12,18 @@ export default function ResourceUtilizationChart({ data }: ResourceUtilizationPr
     setHidden((prev) => ({ ...prev, [key]: !prev[key] }))
   }, [])
 
-  if (!data.length) {
+  const chartData = data.map((d) => ({
+    ...d,
+    cpu: Number.isFinite(d.cpu) ? d.cpu : 0,
+    memory: Number.isFinite(d.memory) ? d.memory : 0,
+  }))
+
+  if (!chartData.length) {
     return <div className="py-8 text-center text-dark-400">No resource data available</div>
   }
 
-  const avgCpu = data.reduce((s, d) => s + d.cpu, 0) / data.length
-  const avgMemory = data.reduce((s, d) => s + d.memory, 0) / data.length
+  const avgCpu = chartData.reduce((s, d) => s + d.cpu, 0) / chartData.length
+  const avgMemory = chartData.reduce((s, d) => s + d.memory, 0) / chartData.length
   const cpuWaste = Math.max(0, 100 - avgCpu)
   const memWaste = Math.max(0, 100 - avgMemory)
 

--- a/frontend/src/components/dashboard/OverviewTab.tsx
+++ b/frontend/src/components/dashboard/OverviewTab.tsx
@@ -67,13 +67,16 @@ export default function OverviewTab({ clusterId }: OverviewTabProps) {
 
   // Formatting helpers
   const ABBREVS: Record<string, string> = { hpa: 'HPA', cpu: 'CPU', gpu: 'GPU', io: 'I/O', aks: 'AKS', eks: 'EKS', gke: 'GKE' }
-  const titleCase = (s: string) => s.replace(/_/g, ' ').replace(/\b\w+/g, (w) => ABBREVS[w.toLowerCase()] || (w.charAt(0).toUpperCase() + w.slice(1)))
+  const titleCase = (s?: string) => (s || 'Unknown')
+    .replace(/_/g, ' ')
+    .replace(/\b\w+/g, (w) => ABBREVS[w.toLowerCase()] || (w.charAt(0).toUpperCase() + w.slice(1)))
 
   // Cost category data (Compute, Storage, Networking, etc.)
   const costCategories = (chartData?.cost_categories as { name: string; value: number }[]) || []
   // Fallback to namespace-based breakdown if no category data
   const costBreakdown = (chartData?.cost_breakdown as { name: string; value: number }[]) || []
   const costDistributionData = (costCategories.length > 0 ? costCategories : costBreakdown)
+    .filter((d) => d?.name)
     .map((d) => ({ ...d, name: titleCase(d.name) }))
 
   const resourceData = (chartData?.resource_utilization as { name: string; cpu: number; memory: number }[]) || []
@@ -94,8 +97,13 @@ export default function OverviewTab({ clusterId }: OverviewTabProps) {
   const nodeRecs = (chartData?.node_recommendations as { node_name: string; current_vm: string; recommended_vm: string; monthly_savings: number; avg_cpu_pct: number; avg_memory_pct: number; priority: string; reasoning?: string }[]) || []
 
   // Compute average CPU/Memory utilization from resourceData for Node Efficiency metric
-  const avgCpu = resourceData.length > 0 ? resourceData.reduce((s, d) => s + d.cpu, 0) / resourceData.length : 0
-  const avgMem = resourceData.length > 0 ? resourceData.reduce((s, d) => s + d.memory, 0) / resourceData.length : 0
+  const validResourceValues = resourceData
+    .map((d) => ({
+      cpu: Number.isFinite(d.cpu) ? d.cpu : 0,
+      memory: Number.isFinite(d.memory) ? d.memory : 0,
+    }))
+  const avgCpu = validResourceValues.length > 0 ? validResourceValues.reduce((s, d) => s + d.cpu, 0) / validResourceValues.length : 0
+  const avgMem = validResourceValues.length > 0 ? validResourceValues.reduce((s, d) => s + d.memory, 0) / validResourceValues.length : 0
   const nodeEfficiency = (avgCpu + avgMem) / 2
 
   // Key metrics (Optimization Score excluded — shown as gauge)

--- a/shared/models/collector.py
+++ b/shared/models/collector.py
@@ -9,7 +9,7 @@ command tunnels (e.g. Azure Run Command).
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field
 
@@ -113,5 +113,9 @@ class CollectorReport(BaseModel):
     total_gpu_requested: int = 0
 
     def is_fresh(self, max_age_seconds: int = 600) -> bool:
-        age = (datetime.utcnow() - self.collected_at).total_seconds()
+        collected_at = self.collected_at
+        if collected_at.tzinfo is None:
+            collected_at = collected_at.replace(tzinfo=timezone.utc)
+        now = datetime.now(collected_at.tzinfo)
+        age = (now - collected_at).total_seconds()
         return age <= max_age_seconds

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -3,7 +3,7 @@
 import json
 import os
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 os.environ.setdefault("LOCAL_DEV", "true")
@@ -31,6 +31,11 @@ class TestCollectorReportSchema:
 
     def test_is_fresh_when_just_collected(self):
         r = CollectorReport(cluster_id="c1")
+        assert r.is_fresh() is True
+
+    def test_is_fresh_accepts_timezone_aware_collector_timestamp(self):
+        collected_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+        r = CollectorReport(cluster_id="c1", collected_at=collected_at)
         assert r.is_fresh() is True
 
     def test_is_stale_when_old(self):
@@ -195,3 +200,31 @@ class TestCollectorPreference:
         store.save(CollectorReport(cluster_id="c1", collected_at=old))
         source = get_data_source("c1", store)
         assert source == DataSource.PROVIDER
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestCollectorAPI:
+    @pytest.mark.asyncio
+    async def test_get_collector_report_accepts_timezone_aware_timestamp(self):
+        from infrastructure.services.collector_store import get_collector_store
+        from presentation.api.v2.routers.collector import get_collector_report
+
+        report = CollectorReport(
+            cluster_id="tz-aware-cluster",
+            collected_at=datetime.now(timezone.utc),
+            total_nodes=1,
+            total_pods=9,
+            metrics_server_available=False,
+        )
+        get_collector_store().save(report)
+
+        response = await get_collector_report("tz-aware-cluster", user={"sub": "test"})
+
+        assert response["cluster_id"] == "tz-aware-cluster"
+        assert response["is_fresh"] is True
+        assert response["nodes"] == 1
+        assert response["pods"] == 9
+        assert response["metrics_server_available"] is False


### PR DESCRIPTION
## Summary
- handle timezone-aware collector timestamps in freshness checks
- add regression coverage for collector GET responses with aware timestamps
- harden dashboard/resource charts against sparse or missing metric values so the cluster detail page does not blank or show NaN%

## Verification
- python3 -m pytest tests/test_collector.py -q
- python3 -m pytest -q
- npm run build
- local browser validation: login, portfolio render, cluster detail render, Run Analysis click, no console errors, no visible NaN%

## Follow-up
- Replace analysis SSE token query parameter with a safer auth path so access logs do not include bearer-equivalent tokens.