### PR TITLE
feat: collector status in portfolio table

### DIFF
--- a/frontend/src/api/collector.ts
+++ b/frontend/src/api/collector.ts
@@ -17,3 +17,11 @@ export async function getCollectorStatus(clusterId: string): Promise<CollectorSt
     return null
   }
 }
+
+export async function getAllCollectorStatuses(): Promise<Record<string, CollectorStatus>> {
+  try {
+    return await api.get('/api/collector/reports')
+  } catch {
+    return {}
+  }
+}

--- a/frontend/src/pages/ClusterPortfolio.tsx
+++ b/frontend/src/pages/ClusterPortfolio.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Plus, RefreshCw, Search, Trash2, ArrowUpDown, DollarSign, TrendingDown, Server, BarChart3, LayoutGrid, List } from 'lucide-react'
+import { Plus, RefreshCw, Search, Trash2, ArrowUpDown, DollarSign, TrendingDown, Server, BarChart3, LayoutGrid, List, Radio } from 'lucide-react'
 import { useClusterStore, type Cluster } from '../store/clusterStore'
 import { getClusters, getPortfolioSummary, removeCluster } from '../api/clusters'
+import { getAllCollectorStatuses, type CollectorStatus } from '../api/collector'
 import { formatCurrency } from '../utils/format'
 import Card from '../components/common/Card'
 import Button from '../components/common/Button'
@@ -52,15 +53,21 @@ export default function ClusterPortfolio() {
   const [providerFilter, setProviderFilter] = useState<ProviderFilter>('all')
   const [confirmDelete, setConfirmDelete] = useState<Cluster | null>(null)
   const [deleting, setDeleting] = useState(false)
+  const [collectorStatuses, setCollectorStatuses] = useState<Record<string, CollectorStatus>>({})
   const navigate = useNavigate()
 
   const fetchData = async () => {
     setLoading(true)
     setError('')
     try {
-      const [clusterRes, summaryRes] = await Promise.all([getClusters(), getPortfolioSummary()])
+      const [clusterRes, summaryRes, statuses] = await Promise.all([
+        getClusters(),
+        getPortfolioSummary(),
+        getAllCollectorStatuses(),
+      ])
       setClusters(clusterRes.clusters)
       setPortfolioSummary(summaryRes)
+      setCollectorStatuses(statuses)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load clusters')
     } finally {
@@ -306,6 +313,7 @@ export default function ClusterPortfolio() {
                   <th className="px-5 py-3.5">Score</th>
                   <th className="px-5 py-3.5">Nodes</th>
                   <th className="px-5 py-3.5">Last Analyzed</th>
+                  <th className="px-5 py-3.5">Data</th>
                   <th className="px-5 py-3.5"></th>
                 </tr>
               </thead>
@@ -344,6 +352,19 @@ export default function ClusterPortfolio() {
                     <td className="px-5 py-3.5" style={{ color: 'var(--text-secondary)' }}>{cluster.node_count ?? '—'}</td>
                     <td className="px-5 py-3.5 text-xs" style={{ color: 'var(--text-muted)' }}>
                       {timeAgo((cluster as unknown as Record<string, unknown>).last_analyzed as string | undefined)}
+                    </td>
+                    <td className="px-5 py-3.5">
+                      {(() => {
+                        const cs = collectorStatuses[cluster.cluster_id]
+                        if (!cs) return <span className="text-xs" style={{ color: 'var(--text-muted)' }}>--</span>
+                        if (cs.is_fresh) return (
+                          <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-cyan, #00D4FF)' }}>
+                            <Radio size={10} />
+                            {timeAgo(cs.collected_at)} &middot; {cs.nodes}n/{cs.pods}p
+                          </span>
+                        )
+                        return <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Stale {timeAgo(cs.collected_at)}</span>
+                      })()}
                     </td>
                     <td className="px-5 py-3.5">
                       <button
@@ -422,6 +443,16 @@ export default function ClusterPortfolio() {
                   <div className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{cluster.node_count ?? '—'}</div>
                 </div>
               </div>
+              {(() => {
+                const cs = collectorStatuses[cluster.cluster_id]
+                if (!cs) return null
+                return (
+                  <div className="mt-2 flex items-center gap-1 text-xs" style={{ color: cs.is_fresh ? 'var(--accent-cyan, #00D4FF)' : 'var(--text-muted)' }}>
+                    <Radio size={10} />
+                    {cs.is_fresh ? `Collected ${timeAgo(cs.collected_at)} · ${cs.nodes}n/${cs.pods}p` : `Stale ${timeAgo(cs.collected_at)}`}
+                  </div>
+                )
+              })()}
             </Card>
           ))}
         </div>

--- a/infrastructure/services/collector_store.py
+++ b/infrastructure/services/collector_store.py
@@ -26,6 +26,10 @@ class CollectorStore:
         with self._lock:
             return self._reports.get(cluster_id)
 
+    def get_all(self) -> dict[str, CollectorReport]:
+        with self._lock:
+            return dict(self._reports)
+
     def has_fresh_report(self, cluster_id: str) -> bool:
         report = self.get(cluster_id)
         if report is None:

--- a/presentation/api/v2/routers/collector.py
+++ b/presentation/api/v2/routers/collector.py
@@ -44,6 +44,26 @@ async def ingest_collector_report(
     }
 
 
+@router.get("/reports")
+async def get_all_collector_reports(
+    user: Dict[str, Any] = Depends(get_current_user),
+):
+    """Return latest collector reports for all clusters in one request."""
+    store = get_collector_store()
+    return {
+        cluster_id: {
+            "cluster_id": report.cluster_id,
+            "collected_at": report.collected_at.isoformat(),
+            "is_fresh": report.is_fresh(),
+            "data_source": get_data_source(cluster_id, store).value,
+            "nodes": report.total_nodes,
+            "pods": report.total_pods,
+            "metrics_server_available": report.metrics_server_available,
+        }
+        for cluster_id, report in store.get_all().items()
+    }
+
+
 @router.get("/report/{cluster_id}")
 async def get_collector_report(
     cluster_id: str,


### PR DESCRIPTION
## Summary

- `CollectorStore.get_all()` -- snapshot of all stored reports (thread-safe)
- `GET /api/collector/reports` -- bulk endpoint, one request for all clusters (no N+1)
- `getAllCollectorStatuses()` -- frontend API function
- Portfolio table: new **Data** column showing `Collected Xm ago · Xn/Xp` (cyan, Radio icon) when fresh, `Stale Xm ago` when old, `--` when no report
- Card view: collector indicator line below bottom row

## Test plan

- [ ] 66 tests pass (`pytest -q`)
- [ ] TypeScript compiles clean (`tsc --noEmit`)
- [ ] `kubectl apply -f deploy/kubernetes/kubeopt-collector.yaml` on a live cluster -- portfolio row shows live collector status within 5 minutes
- [ ] Demo clusters (no collector) show `--` in Data column