### PR TITLE
Expose collector metrics diagnostics

### DIFF
--- a/deploy/kubernetes/kubeopt-collector.yaml
+++ b/deploy/kubernetes/kubeopt-collector.yaml
@@ -202,6 +202,24 @@ data:
         with urllib.request.urlopen(req, context=ctx, timeout=15) as r:
             return json.loads(r.read())
 
+    def _classify_metrics_error(exc):
+        if isinstance(exc, urllib.error.HTTPError):
+            if exc.code in (401, 403):
+                return "rbac_denied"
+            if exc.code == 404:
+                return "metrics_api_not_found"
+            return f"http_{exc.code}"
+        if isinstance(exc, TimeoutError):
+            return "timeout"
+        if isinstance(exc, urllib.error.URLError):
+            reason = str(exc.reason).lower()
+            if "timed out" in reason:
+                return "timeout"
+            if "refused" in reason or "unreachable" in reason or "temporary failure" in reason:
+                return "network_unreachable"
+            return "connection_error"
+        return exc.__class__.__name__
+
     def _metrics_get(path):
         token = _k8s_token()
         url = f"{METRICS_SERVER}{path}"
@@ -209,9 +227,11 @@ data:
         ctx = ssl.create_default_context(cafile=CA_CERT_PATH)
         try:
             with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
-                return json.loads(r.read()), True
-        except Exception:
-            return {}, False
+                return json.loads(r.read()), True, None
+        except Exception as exc:
+            reason = _classify_metrics_error(exc)
+            log.warning("metrics-server unavailable: %s", reason)
+            return {}, False, reason
 
     def _parse_cpu(val):
         """Convert CPU string (e.g. '500m', '2') to millicores int."""
@@ -246,12 +266,14 @@ data:
             "services": [],
             "namespaces": [],
             "metrics_server_available": False,
+            "metrics_server_error": None,
         }
 
         # Nodes
         nodes_raw = _k8s_get("/api/v1/nodes")
-        node_metrics, metrics_ok = _metrics_get("/nodes")
+        node_metrics, metrics_ok, metrics_error = _metrics_get("/nodes")
         report["metrics_server_available"] = metrics_ok
+        report["metrics_server_error"] = metrics_error
         node_usage = {i["metadata"]["name"]: i["usage"] for i in node_metrics.get("items", [])}
 
         for n in nodes_raw.get("items", []):
@@ -280,7 +302,11 @@ data:
 
         # Pods
         pods_raw = _k8s_get("/api/v1/pods")
-        pod_metrics, _ = _metrics_get("/pods")
+        pod_metrics, pods_metrics_ok, pods_metrics_error = _metrics_get("/pods")
+        if metrics_ok and not pods_metrics_ok:
+            report["metrics_server_available"] = False
+            report["metrics_server_error"] = pods_metrics_error
+            metrics_ok = False
         pod_usage = {
             f"{i['metadata']['namespace']}/{i['metadata']['name']}": i["containers"]
             for i in pod_metrics.get("items", [])

--- a/frontend/src/api/collector.ts
+++ b/frontend/src/api/collector.ts
@@ -8,6 +8,7 @@ export interface CollectorStatus {
   nodes: number
   pods: number
   metrics_server_available: boolean
+  metrics_server_error?: string | null
 }
 
 export async function getCollectorStatus(clusterId: string): Promise<CollectorStatus | null> {

--- a/frontend/src/components/dashboard/OverviewTab.tsx
+++ b/frontend/src/components/dashboard/OverviewTab.tsx
@@ -120,6 +120,9 @@ export default function OverviewTab({ clusterId }: OverviewTabProps) {
       ? `Collector active -- ${new Date(collectorStatus.collected_at).toLocaleTimeString()} (${collectorStatus.nodes}n / ${collectorStatus.pods}p)`
       : `Collector stale -- last report ${new Date(collectorStatus.collected_at).toLocaleTimeString()}`
     : null
+  const collectorMetricsLabel = collectorStatus && !collectorStatus.metrics_server_available
+    ? ` -- metrics: ${(collectorStatus.metrics_server_error || 'unavailable').replace(/_/g, ' ')}`
+    : ''
 
   return (
     <div className="space-y-6">
@@ -130,7 +133,7 @@ export default function OverviewTab({ clusterId }: OverviewTabProps) {
             style={{ color: collectorStatus?.is_fresh ? 'var(--accent-cyan, #00D4FF)' : 'var(--text-muted)' }}
           >
             <Radio size={11} />
-            {collectorLabel}
+            {collectorLabel}{collectorMetricsLabel}
           </span>
         ) : <span />}
         {lastRefresh && (

--- a/frontend/src/pages/ClusterPortfolio.tsx
+++ b/frontend/src/pages/ClusterPortfolio.tsx
@@ -26,6 +26,14 @@ function timeAgo(dateStr?: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
+function metricsStatusLabel(status: CollectorStatus): string {
+  if (status.metrics_server_available) return ''
+  const reason = status.metrics_server_error
+    ? status.metrics_server_error.replace(/_/g, ' ')
+    : 'metrics unavailable'
+  return ` · ${reason}`
+}
+
 function ScoreBadge({ score }: { score: number }) {
   const color = score >= 80 ? 'green' : score >= 60 ? 'yellow' : 'red'
   return <Badge variant={color}>{score.toFixed(0)}%</Badge>
@@ -358,12 +366,16 @@ export default function ClusterPortfolio() {
                         const cs = collectorStatuses[cluster.cluster_id]
                         if (!cs) return <span className="text-xs" style={{ color: 'var(--text-muted)' }}>--</span>
                         if (cs.is_fresh) return (
-                          <span className="flex items-center gap-1 text-xs" style={{ color: 'var(--accent-cyan, #00D4FF)' }}>
+                          <span
+                            className="flex items-center gap-1 text-xs"
+                            style={{ color: 'var(--accent-cyan, #00D4FF)' }}
+                            title={cs.metrics_server_available ? 'Collector metrics available' : `Collector metrics unavailable: ${cs.metrics_server_error || 'unknown reason'}`}
+                          >
                             <Radio size={10} />
-                            {timeAgo(cs.collected_at)} &middot; {cs.nodes}n/{cs.pods}p
+                            {timeAgo(cs.collected_at)} &middot; {cs.nodes}n/{cs.pods}p{metricsStatusLabel(cs)}
                           </span>
                         )
-                        return <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Stale {timeAgo(cs.collected_at)}</span>
+                        return <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Stale {timeAgo(cs.collected_at)}{metricsStatusLabel(cs)}</span>
                       })()}
                     </td>
                     <td className="px-5 py-3.5">
@@ -449,7 +461,9 @@ export default function ClusterPortfolio() {
                 return (
                   <div className="mt-2 flex items-center gap-1 text-xs" style={{ color: cs.is_fresh ? 'var(--accent-cyan, #00D4FF)' : 'var(--text-muted)' }}>
                     <Radio size={10} />
-                    {cs.is_fresh ? `Collected ${timeAgo(cs.collected_at)} · ${cs.nodes}n/${cs.pods}p` : `Stale ${timeAgo(cs.collected_at)}`}
+                    {cs.is_fresh
+                      ? `Collected ${timeAgo(cs.collected_at)} · ${cs.nodes}n/${cs.pods}p${metricsStatusLabel(cs)}`
+                      : `Stale ${timeAgo(cs.collected_at)}${metricsStatusLabel(cs)}`}
                   </div>
                 )
               })()}

--- a/presentation/api/v2/routers/collector.py
+++ b/presentation/api/v2/routers/collector.py
@@ -59,6 +59,7 @@ async def get_all_collector_reports(
             "nodes": report.total_nodes,
             "pods": report.total_pods,
             "metrics_server_available": report.metrics_server_available,
+            "metrics_server_error": report.metrics_server_error,
         }
         for cluster_id, report in store.get_all().items()
     }
@@ -82,4 +83,5 @@ async def get_collector_report(
         "nodes": report.total_nodes,
         "pods": report.total_pods,
         "metrics_server_available": report.metrics_server_available,
+        "metrics_server_error": report.metrics_server_error,
     }

--- a/shared/models/collector.py
+++ b/shared/models/collector.py
@@ -107,6 +107,7 @@ class CollectorReport(BaseModel):
     total_cpu_requested_m: int = 0
     total_memory_requested_mb: int = 0
     metrics_server_available: bool = False
+    metrics_server_error: Optional[str] = None
 
     # GPU summary (0 when no GPU workloads present)
     total_gpu_pods: int = 0

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -27,6 +27,7 @@ class TestCollectorReportSchema:
         assert r.cluster_id == "c1"
         assert r.total_nodes == 0
         assert r.metrics_server_available is False
+        assert r.metrics_server_error is None
         assert isinstance(r.collected_at, datetime)
 
     def test_is_fresh_when_just_collected(self):
@@ -127,6 +128,16 @@ class TestCollectorFixtures:
         for pod in r.pods:
             assert pod.cpu_used_m is None
 
+    def test_report_preserves_metrics_server_error_reason(self):
+        r = CollectorReport(
+            cluster_id="c1",
+            metrics_server_available=False,
+            metrics_server_error="rbac_denied",
+        )
+        dumped = r.model_dump()
+        restored = CollectorReport(**dumped)
+        assert restored.metrics_server_error == "rbac_denied"
+
 
 # ---------------------------------------------------------------------------
 # CollectorStore tests
@@ -218,6 +229,7 @@ class TestCollectorAPI:
             total_nodes=1,
             total_pods=9,
             metrics_server_available=False,
+            metrics_server_error="network_unreachable",
         )
         get_collector_store().save(report)
 
@@ -228,3 +240,4 @@ class TestCollectorAPI:
         assert response["nodes"] == 1
         assert response["pods"] == 9
         assert response["metrics_server_available"] is False
+        assert response["metrics_server_error"] == "network_unreachable"


### PR DESCRIPTION
## Summary
- add metrics_server_error to CollectorReport so metrics failures carry a reason, not only a boolean
- classify collector metrics-server failures as rbac_denied, metrics_api_not_found, timeout, network_unreachable, connection_error, or HTTP status
- return metrics_server_error from single and bulk collector status APIs
- surface the metrics reason in the portfolio Data column and cluster detail collector badge

## Why
This addresses RBAC/NetworkPolicy feedback from the CNCF/community thread: KubeOpt should distinguish metrics-server unavailable from RBAC denied or connectivity blocked.

## Verification
- embedded collector.py from kubeopt-collector.yaml compiles
- python3 -m pytest tests/test_collector.py -q
- python3 -m pytest -q
- npm run build